### PR TITLE
[WS-pscan-scripts_js] Add Error Application Disclosure Script

### DIFF
--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -22,6 +22,10 @@ package org.zaproxy.zap.extension.websocket;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,10 +33,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import javax.swing.ImageIcon;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -74,6 +80,7 @@ import org.zaproxy.zap.extension.httppanel.view.HttpPanelView;
 import org.zaproxy.zap.extension.httppanel.view.hex.HttpPanelHexView;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptType;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.websocket.alerts.AlertManager;
 import org.zaproxy.zap.extension.websocket.brk.PopupMenuAddBreakWebSocket;
 import org.zaproxy.zap.extension.websocket.brk.WebSocketBreakpointMessageHandler;
@@ -147,6 +154,9 @@ public class ExtensionWebSocket extends ExtensionAdaptor
     /** Used to identify the type of Websocket passive scan scripts */
     public static final String SCRIPT_TYPE_WEBSOCKET_PASSIVE = "websocketpassive";
 
+    /** Used to add the default scripts */
+    private static final String SCRIPTS_FOLDER = Constant.getZapHome() + "/scripts/scripts/";
+
     /** Used to shorten the time, a listener is started on a WebSocket channel. */
     private ExecutorService listenerThreadPool;
 
@@ -214,6 +224,8 @@ public class ExtensionWebSocket extends ExtensionAdaptor
     private ScriptType websocketPassiveScanScriptType;
 
     private WebSocketPassiveScannerManager webSocketPassiveScannerManager = null;
+
+    private ExtensionScript extensionScript = null;
 
     public ExtensionWebSocket() {
         super(NAME);
@@ -390,16 +402,16 @@ public class ExtensionWebSocket extends ExtensionAdaptor
             }
         }
         // setup sender script interface
-        ExtensionScript extensionScript =
+        this.extensionScript =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
-        if (extensionScript != null) {
+        if (this.extensionScript != null) {
             websocketSenderSciptType =
                     new ScriptType(
                             SCRIPT_TYPE_WEBSOCKET_SENDER,
                             "websocket.script.type.websocketsender",
                             getView() != null ? getScriptSenderIcon() : null,
                             true);
-            extensionScript.registerScriptType(websocketSenderSciptType);
+            this.extensionScript.registerScriptType(websocketSenderSciptType);
             webSocketSenderScriptListener = new WebSocketSenderScriptListener();
             addAllChannelSenderListener(webSocketSenderScriptListener);
         }
@@ -428,7 +440,7 @@ public class ExtensionWebSocket extends ExtensionAdaptor
                             "websocket.pscan.scripts.type.passive",
                             getView() != null ? getScriptPassiveScanIcon() : null,
                             true);
-            extensionScript.registerScriptType(websocketPassiveScanScriptType);
+            this.extensionScript.registerScriptType(websocketPassiveScanScriptType);
             webSocketScriptPassiveScanner = new ScriptsWebSocketPassiveScanner();
 
             webSocketPassiveScannerManager.add(webSocketScriptPassiveScanner);
@@ -441,8 +453,12 @@ public class ExtensionWebSocket extends ExtensionAdaptor
     public void postInit() {
         super.postInit();
 
-        if (webSocketPassiveScannerManager != null && !webSocketPassiveScannerManager.hasTable()) {
-            webSocketPassiveScannerManager.setTable(table);
+        if (webSocketPassiveScannerManager != null) {
+            registerUserScripts(websocketPassiveScanScriptType);
+
+            if (!webSocketPassiveScannerManager.hasTable()) {
+                webSocketPassiveScannerManager.setTable(table);
+            }
         }
     }
 
@@ -533,6 +549,57 @@ public class ExtensionWebSocket extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("websocket.desc");
+    }
+
+    private void registerUserScripts(ScriptType scriptType) {
+        String folder = SCRIPTS_FOLDER + scriptType.getName() + '/';
+        Path scriptFolderPath = Paths.get(folder);
+        try (Stream<Path> scriptFilePaths = Files.list(scriptFolderPath)) {
+            scriptFilePaths
+                    .map(path -> path.toFile())
+                    .filter(file -> file.isFile()) // Keep only those which are files
+                    .map(
+                            file -> {
+                                return new ScriptWrapper(
+                                        file.getName(),
+                                        "",
+                                        extensionScript.getEngineNameForExtension(
+                                                file.getName()
+                                                        .substring(
+                                                                file.getName().lastIndexOf(".")
+                                                                        + 1)),
+                                        scriptType,
+                                        true,
+                                        file);
+                            })
+
+                    // Load the scripts from ExtensionScript(if not an IOException)
+                    .map(scriptWrapper -> loadScript(scriptWrapper))
+                    // Check if they are null
+                    .filter(maybeScriptWrapper -> maybeScriptWrapper.isPresent())
+                    // Get the ScriptWrapper
+                    .map(maybeScriptWrapper -> maybeScriptWrapper.get())
+                    .filter(
+                            scriptWrapper ->
+                                    this.extensionScript.getScript(scriptWrapper.getName()) == null)
+                    .forEach(scriptWrapper -> this.extensionScript.addScript(scriptWrapper, false));
+
+        } catch (NoSuchFileException e) {
+            return;
+        } catch (IOException e) {
+            logger.warn(
+                    "A problem occurred while trying to import scripts for " + scriptType.getName(),
+                    e);
+        }
+    }
+
+    private Optional<ScriptWrapper> loadScript(ScriptWrapper scriptWrapper) {
+        try {
+            return Optional.of(this.extensionScript.loadScript(scriptWrapper));
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+            return Optional.empty();
+        }
     }
 
     /**

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/scripts/websocketpassive/application_error_scanner.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/scripts/websocketpassive/application_error_scanner.js
@@ -1,0 +1,134 @@
+// * This Script analyzes incoming websocket messages for error messages
+
+// * Based on org.zaproxy.zap.extension.pscanrules.ApplicationErrorScanner
+// * Application error strings are equal to:
+// ** https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/application_errors.xml
+
+// Author: Manos Kirtas (manolis.kirt@gmail.com)
+
+OPCODE_TEXT = 0x1;
+RISK_MEDIUM = 2;
+CONFIDENCE_MEDIUM = 2;
+
+var strings_microsoft_db_error = [/Microsoft OLE DB Provider for ODBC Drivers/igm,
+                                           /Microsoft OLE DB Provider for SQL Server/igm,
+                                           /ODBC Microsoft Access Driver/igm,
+                                           /ODBC SQL Server Driver/igm];
+
+var strings_msql_error = [/supplied argument is not a valid MySQL result/igm,
+                          /Invalid parameter type/igm,
+                          /You have an error in your SQL syntax/igm,
+                          /Incorrect column name/igm,
+                          /Can't find record in/igm,
+                          /Unknown table/igm,
+                          /Incorrect column specifier for column/igm,
+                          /Column count doesn't match value count at row/igm,
+                          /Unclosed quotation mark before the character string/igm,
+                          /java\.lang\.NumberFormatException: For input string:/igm,
+                          /\): encountered SQLException \[/igm,
+                          /Unexpected end of command in statement \[/igm,
+                          /Invalid SQL:/igm,
+                          /ERROR: parser: parse error at or near/igm,
+                          /\[ODBC Informix driver\]\[Informix\]/igm,
+                          /\[Microsoft\]\[ODBC Microsoft Access 97 Driver\]/igm,
+                          /\[SQL Server Driver\]\[SQL Server\]Line 1: Incorrect syntax near/igm,
+                          /SQL command not properly ended/igm,
+                          /unexpected end of SQL command/igm,
+                          /Supplied argument is not a valid PostgreSQL result/igm,
+                          /internal error \[IBM\]\[CLI Driver\]\[DB2\/6000\]/igm,
+                          /Error Occurred While Processing Request/igm,
+                          /internal error/igm,
+                          /A syntax error has occurred/igm,
+                          /ADODB\.Field error/igm,
+                          /ASP\.NET is configured to show verbose error messages/igm,
+                          /ASP\.NET_SessionId/igm,
+                          /Active Server Pages error/igm,
+                          /An illegal character has been found in the statement/igm,
+                          /An unexpected token "END-OF-STATEMENT" was found/igm,
+                          /Can't connect to local/igm,
+                          /Custom Error Message/igm,
+                          /DB2 Driver/igm,
+                          /DB2 Error/igm,
+                          /DB2 ODBC/igm,
+                          /Disallowed Parent Path/igm,
+                          /Error Diagnostic Information/igm,
+                          /Error Message : Error loading required libraries\./igm,
+                          /Error Report/igm,
+                          /Error converting data type varchar to numeric/igm,
+                          /Internal Server Error/igm,
+                          /Invalid Path Character/igm,
+                          /Invalid procedure call or argument/igm,
+                          /Invision Power Board Database Error/igm,
+                          /JDBC Driver/igm,
+                          /JDBC Error/igm,
+                          /JDBC MySQL/igm,
+                          /JDBC Oracle/igm,
+                          /JDBC SQL/igm,
+                          /Microsoft VBScript compilation error/igm,
+                          /Microsoft VBScript error/igm,
+                          /MySQL Driver/igm,
+                          /MySQL Error/igm,
+                          /MySQL ODBC/igm,
+                          /ODBC DB2/igm,
+                          /ODBC Driver/igm,
+                          /ODBC Error/igm,
+                          /ODBC Oracle/igm,
+                          /OLE\/DB provider returned message/igm,
+                          /Oracle DB2/igm,
+                          /Oracle Driver/igm,
+                          /Oracle Error/igm,
+                          /Oracle ODBC/igm,
+                          /PHP Error/igm,
+                          /PHP Parse error/igm,
+                          /PHP Warning/igm,
+                          /Parent Directory/igm,
+                          /Permission denied: 'GetObject'/igm,
+                          /PostgreSQL query failed: ERROR: parser: parse error/igm,
+                          /The script whose uid is/igm,
+                          /Type mismatch/igm,
+                          /Unable to jump to row/igm,
+                          /Unterminated string constant/igm,
+                          /Warning: Cannot modify header information - headers already sent/igm,
+                          /Warning: Supplied argument is not a valid File-Handle resource in/igm,
+                          /Warning: mysql_query\(\)/igm,
+                          /Warning: pg_connect\(\): Unable to connect to PostgreSQL server: FATAL/igm,
+                          /data source=/igm,
+                          /invalid query/igm,
+                          /is not allowed to access/igm,
+                          /mySQL error with query/igm,
+                          /on MySQL result index/igm,
+                          /server object error/igm];
+
+function scan(helper,msg) {
+
+    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+        return;
+    }
+    var message = String(msg.getReadablePayload()).valueOf();
+
+    strings_msql_error.forEach(function(pattern){
+        if((matches = message.match(pattern)) != null){
+            matches.forEach(function(evidence){
+
+                helper.newAlert()
+                    .setRiskConfidence(RISK_MEDIUM, CONFIDENCE_MEDIUM)
+                    .setName("Application Error Disclosure via WebSockets (script)")
+                    .setDescription(
+                        "This page contains an error/warning message that \
+ may disclose sensitive information like the location of the file \
+ that produced the unhandled exception. This information can be used\
+ to launch further attacks against the web application. The alert\
+ could be a false positive if the error message is found inside a\
+ documentation page.")
+                    .setSolution("Review the source code of this page. Implement custom \
+ error pages. Consider implementing a mechanism to provide a unique\
+ error reference/identifier to the client (browser) while logging the\
+ details on the server side and not exposing them to the user.")
+                    .setEvidence(evidence)
+                    .setCweId(209) // Information Exposure Through an Error Message
+                    .setWascId(200) // Information Leakage
+                    .raise();
+            });
+        }
+    });
+}

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/scripts/websocketpassive/application_error_scanner_regex.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/scripts/websocketpassive/application_error_scanner_regex.js
@@ -1,0 +1,70 @@
+// * This Script analyzes incoming websocket messages for error messages with a set of regular expressions
+
+// * Based on org.zaproxy.zap.extension.pscanrules.ApplicationErrorScanner
+// * Application error strings are equal to (characters '/' is escaped -> '//'):
+// ** https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/application_errors.xml
+
+// Author: Manos Kirtas (manolis.kirt@gmail.com)
+
+OPCODE_TEXT = 0x1;
+RISK_MEDIUM = 2;
+CONFIDENCE_MEDIUM = 2;
+
+patterns = ["(?i)Line\\s\\d+:\\sIncorrect\\ssyntax\\snear\\s'[^']*'",
+            "(?i)pg_query\\(\\)[:]*\\squery\\sfailed:\\serror:\\s",
+            "(?i)'[^']*'\\sis\\snull\\sor\\snot\\san\\sobject",
+            "(?i)ORA\\-\\d{4,5}:\\s",
+            "(?i)Microsoft\\sJET\\sDatabase\\sEngine\\s\\([^\\)]*\\)&lt;br&gt;Syntax\\serror(.*)\\sin\\squery\\sexpression\\s'.*\\.&lt;br&gt;&lt;b&gt;.*,\\sline\\s\\d+&lt;/b&gt;&lt;br&gt;",
+            "(?i)&lt;h2&gt;\\s&lt;i&gt;Syntax\\serror\\s(\\([^\\)]*\\))?(in\\sstring)?\\sin\\squery\\sexpression\\s'[^\\.]*\\.&lt;/i&gt;\\s&lt;/h2&gt;&lt;/span&gt;",
+            "(?i)&lt;font\\sface=\"Arial\"\\ssize=2&gt;Syntax\\serror\\s(.*)?in\\squery\\sexpression\\s'(.*)\\.&lt;/font&gt;",
+            "(?i)&lt;b&gt;Warning&lt;/b&gt;:\\s\\spg_exec\\(\\)\\s\\[\\&lt;a\\shref='function.pg\\-exec\\'\\&gt;function\\.pg-exec\\&lt;/a&gt;\\]\\:\\sQuery failed:\\sERROR:\\s\\ssyntax error at or near \\&amp;quot\\;\\\\\\&amp;quot; at character \\d+ in\\s&lt;b&gt;.*&lt;/b&gt;",
+            "(?i)System\\.Data\\.OleDb\\.OleDbException\\:\\sSyntax\\serror\\s\\([^)]*?\\)\\sin\\squery\\sexpression\\s.*",
+            "(?i)System\\.Data\\.OleDb\\.OleDbException\\:\\sSyntax\\serror\\sin\\sstring\\sin\\squery\\sexpression\\s",
+            "&lt;font style=\"COLOR: black; FONT: 8pt/11pt verdana\"&gt;\\s+(\\[Macromedia\\]\\[SQLServer\\sJDBC\\sDriver\\]\\[SQLServer\\]|Syntax\\serror\\sin\\sstring\\sin\\squery\\sexpression\\s)",
+            "(?i)The Error Occurred in &lt;b&gt;(.*): line.*&lt;\/b&gt;&lt;br&gt;",
+            "(?i)The error occurred while processing.*Template: (.*) &lt;br&gt;.",
+            "(?i)The error occurred while processing.*in the template file (.*)\\.&lt;\/p&gt;&lt;br&gt;",
+            "(?i)&lt;span&gt;&lt;H1&gt;Server\\sError\\sin\\s'[^']*'\\sApplication\\.&lt;hr\\swidth=100%\\ssize=1\\scolor=silver&gt;&lt;/H1&gt;",
+            "(?i)&lt;title&gt;Invalid\\sfile\\sname\\sfor\\smonitoring:\\s'([^']*)'\\.\\sFile\\snames\\sfor\\smonitoring\\smust\\shave\\sabsolute\\spaths\\,\\sand\\sno\\swildcards\\.&lt;/title&gt;",
+            "(?i)&lt;b&gt;(Warning|Fatal\\serror|Parse\\serror)&lt;/b&gt;:\\s+.*?\\sin\\s&lt;b&gt;.*?&lt;/b&gt;\\son\\sline\\s&lt;b&gt;\\d*?&lt;/b&gt;&lt;br\\s/&gt;",
+            "(?:Unknown database '.*?')|(?:No database selected)|(?:Table '.*?' doesn't exist)|(?:You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '.*?' at line .*?)",
+            "Exception report.*message.*description.*exception.*note.*",
+            "(?i)&lt;head&gt;&lt;title&gt;JRun Servlet Error&lt;/title&gt;&lt;/head&gt;",
+            "(?i)&lt;h1&gt;Servlet\\sError:\\s\\w+?&lt;/h1&gt;",
+            "(?i)Servlet\\sError&lt;/title&gt;"];
+
+var errorPatterns = [];
+patterns.forEach(function(pattern){
+    errorPatterns.push(java.util.regex.Pattern.compile(pattern));
+});
+
+function scan(helper,msg) {
+
+    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+        return;
+    }
+    var message = String(msg.getReadablePayload()).valueOf();
+
+    errorPatterns.forEach(function(pattern){
+        var matcher = pattern.matcher(message);
+        while(matcher.find()){
+            helper.newAlert()
+                .setRiskConfidence(RISK_MEDIUM, CONFIDENCE_MEDIUM)
+                .setName("Application Error Disclosure via WebSockets (regex-script)")
+                .setDescription("This page contains an error/warning message that \
+ may disclose sensitive information like the location of the file \
+ that produced the unhandled exception. This information can be used\
+ to launch further attacks against the web application. The alert\
+ could be a false positive if the error message is found inside a\
+ documentation page.")
+                .setSolution("Review the source code of this page. Implement custom \
+ error pages. Consider implementing a mechanism to provide a unique\
+ error reference/identifier to the client (browser) while logging the\
+ details on the server side and not exposing them to the user.")
+                .setEvidence(String(matcher.group()))
+                .setCweId(209) // Information Exposure Through an Error Message
+                .setWascId(200) //Information Leakage
+                .raise();
+        }
+    });
+}


### PR DESCRIPTION
I split the Error Application Disclosure scanner into two scripts one is using string and the other using regex.


**NOTE:** Application error strings are equal to (the only difference is that characters '/' is escaped -> '//' )

_______________________________________________________________________
**Test Example:** 
```JS
json-test : {
	  "base64-no-=" : "SGVsbG8gV29ybGQh",
	  "base64-with-=" : "SGVsbG8gV29ybGQ=",
	  "non-base64" : "Hello World",
	  "non-base64-with" : "1+2=3",
	  "non_base64_with_2" : "1234==",
	  "an-email": "example@email.com",
    "application-error": "Warning: Cannot modify header information - headers already sent",
    "app-error-regex_1" : "Line 54: Incorrect syntax near 'here'"
    "app-error-regex_2" : "pg_query(): query failed: error: ",
    "app-error-regex_3" : "pg_query(): Query failed: ERROR: column \"tom\" does not exist LINE 2: SET name=tom",
    "app-error-regex_4" : "'it's a text' is null or not an object",
    "app-error-regex_5" : "ORA-30625: method dispatch on NULL SELF argument is disallowed\n"
        + "Cause: A member method of a type is being invoked with a NULL SELF argument.\n"
        + "Action: Change the method invocation to pass in a valid self argument.",
    "app-error-regex_6 : "System.Data.OleDb.OleDbException: Syntax error in string in query expression 'User ID = ? And Password = ?'"
}

}
```
